### PR TITLE
add initialState property to contacts

### DIFF
--- a/app/assets/javascripts/app/routes/app_router.js
+++ b/app/assets/javascripts/app/routes/app_router.js
@@ -4,6 +4,7 @@ App.Router = Ember.Router.extend({
   root: Em.Route.extend({
     contacts: Em.Route.extend({
       route: '/',
+      initialState: 'index',
       
       showContact: function(router, event) {
         router.transitionTo('contacts.contact.index', event.context);


### PR DESCRIPTION
When entering the contacts route, it tells the router to go to its `index` sub route
It fixes the fact that reloading a page at contacts/1 displays nothing
