### PR TITLE
Update active_model_serializers github URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :assets do
   gem 'anjlab-bootstrap-rails', '>= 2.1', :require => 'bootstrap-rails'
 end
 
-gem 'active_model_serializers', github: 'josevalim/active_model_serializers'
+gem 'active_model_serializers', github: 'rails-api/active_model_serializers'
 gem 'jquery-rails'
 gem 'ember-rails', '>= 0.4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/josevalim/active_model_serializers.git
+  remote: git://github.com/rails-api/active_model_serializers.git
   revision: a21529370cb1fef30af92393ee209c53a6c86ba8
   specs:
     active_model_serializers (0.5.0)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a simple Rails 3.2 app created to demo [Ember.js](https://github.com/emberjs/ember.js),
 [Ember-Data](https://github.com/emberjs/data) and
-[Active Model Serializers](https://github.com/josevalim/active_model_serializers).
+[Active Model Serializers](https://github.com/rails-api/active_model_serializers).
 It uses the edge versions of Ember (post 1.0.pre) and Ember Data (after the merge of the relationship-improvements branch),
 and therefore may be unstable.
 


### PR DESCRIPTION
active_model_serializers has moved from josevalim/... to rails-api/... , breaking `bundle install`.

I updated the Gemfile.lock file manually, which probably isn't the correct way... but `bundle install`, etc., worked locally, afterward, so...
