### PR TITLE
Corrected Gemfile :git => syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ group :assets do
   gem 'anjlab-bootstrap-rails', '>= 2.1', :require => 'bootstrap-rails'
 end
 
-gem 'active_model_serializers', github: 'rails-api/active_model_serializers'
+gem "active_model_serializers", :git => "git://github.com/rails-api/active_model_serializers.git"
 gem 'jquery-rails'
 gem 'ember-rails', '>= 0.4.0'
 
 group :test do
   # Pretty printed test output
-  gem 'turn', '~> 0.8.3', require: false
+  gem 'turn', '~> 0.8.3', :require => false
 end


### PR DESCRIPTION
Fixed syntax errors

```
Gemfile syntax error:
./ember_data_example-master/Gemfile:20: syntax error, unexpected ':', expecting kEND
  gem 'turn', '~> 0.8.3', require: false
```
