### PR TITLE
Mappings are preferably declared on the adapter

### DIFF
--- a/app/assets/javascripts/store.js
+++ b/app/assets/javascripts/store.js
@@ -1,16 +1,9 @@
-App.RESTSerializer = DS.RESTSerializer.extend({
-  init: function() {
-    this._super();
-
-    this.map('App.Contact', {
-      phoneNumbers: {embedded: 'always'}
-    });
-  }
+App.Adapter = DS.RESTAdapter.extend({
+  bulkCommit: false
 });
 
-App.Adapter = DS.RESTAdapter.extend({
-  bulkCommit: false,
-  serializer: App.RESTSerializer.create()
+App.Adapter.map('App.Contact', {
+  phoneNumbers: {embedded: 'always'}
 });
 
 App.Store = DS.Store.extend({


### PR DESCRIPTION
Cleaning the code by setting the mapping on the adapter which avoids to modify manually the serializer.
