### PR TITLE
Added 'therubyracer' dependency for development 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :test, :development do
   gem 'capybara'
   gem 'konacha'
   gem 'poltergeist'
+  gem 'therubyracer'
 end
 
 group :test do


### PR DESCRIPTION
It was raising an error for me on a mac os x 10.8 visiting the application after starting the server with "rails s".
Adding "gem 'therubyracer'" to the Gemfile and running "bundle install" again solved the problem.
