### PR TITLE
Update therubyracer gem to work on Mavericks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :assets do
   gem 'sass-rails'
   gem 'uglifier'
   gem 'anjlab-bootstrap-rails', '>= 2.1', :require => 'bootstrap-rails'
-  gem 'therubyracer', :platforms => :ruby
+  gem 'therubyracer', '~> 0.12.0', :platforms => :ruby
 end
 
 gem 'active_model_serializers', github: 'rails-api/active_model_serializers'


### PR DESCRIPTION
As per http://blog.blenderbox.com/2013/11/13/an-error-occurred-while-installing-libv8-mavericks/
